### PR TITLE
添加流量重置脚本&添加Base64中文支持

### DIFF
--- a/server/cron.php
+++ b/server/cron.php
@@ -1,0 +1,21 @@
+<?php
+//读取数据库连接信息
+$json_string = file_get_contents(__DIR__ . '/sqlconn.json');
+$data = json_decode($json_string, true);
+//连接数据库
+try {
+	$sql = new PDO("mysql:host=" . $data['host'] . ";port=" . strval($data['port']) . ";dbname=" . $data['db'], $data['user'], $data['password']);
+	$sql -> setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+} catch (PDOException $e) {
+	die ("错误: " . $e->getMessage() . "\n");
+}
+die("成功: 连接数据库。" . "\n");
+$sql -> exec("set names utf8");
+//执行重置流量语句
+try {
+    $sql_results  = $sql -> query("UPDATE user SET uplink=0 , downlink=0 , updated_at=" . time() . " WHERE need_reset=1");
+	die ("成功: 重置了" . $sql_results->rowCount() . "个用户的流量。" . "\n");
+} catch (PDOException $e) {
+    die ("错误: " . $e->getMessage() . "\n");
+}
+?>

--- a/whmcs/modules/servers/V2rayMS/templates/static/js/script.js
+++ b/whmcs/modules/servers/V2rayMS/templates/static/js/script.js
@@ -2,6 +2,7 @@ var base64EncodeChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz012
 function base64encode(str) {
     var out, i, len;
     var c1, c2, c3;
+    str = utf8_encode(str);
     len = str.length;
     i = 0;
     out = "";
@@ -28,6 +29,24 @@ function base64encode(str) {
         out += base64EncodeChars.charAt(c3 & 0x3F);
     }
     return out;
+}
+function utf8_encode(str) {
+    str = str.replace(/\r\n/g, "\n");
+    var utftext = "";
+    for (var n = 0; n < str.length; n++) {
+        var c = str.charCodeAt(n);
+        if (c < 128) {
+            utftext += String.fromCharCode(c);
+        } else if ((c > 127) && (c < 2048)) {
+            utftext += String.fromCharCode((c >> 6) | 192);
+            utftext += String.fromCharCode((c & 63) | 128);
+        } else {
+            utftext += String.fromCharCode((c >> 12) | 224);
+            utftext += String.fromCharCode(((c >> 6) & 63) | 128);
+            utftext += String.fromCharCode((c & 63) | 128);
+        }
+    }
+    return utftext;
 }
 $(document).ready(function() {
 	jQuery(document).ready(function($) {


### PR DESCRIPTION
添加流量重置脚本，可用定时任务每月月初执行php命令。
添加Base64中文支持，原来的base64encode会使得二维码和vmess链接decode出来的中文变成乱码，不过这个现象如果不将服务器别名添加进json好像发现不了。